### PR TITLE
Cherry pick from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-	"client/consensus/nimbus-consensus",
-	"precompiles/*",
-	"pallets/*",
-	"primitives/*",
-	"template/node",
-	"template/runtime",
-	"template/pallets/template",
+    "client/consensus/nimbus-consensus",
+    "precompiles/*",
+    "pallets/*",
+    "primitives/*",
+    "template/node",
+    "template/runtime",
+    "template/pallets/template",
 ]
 resolver = "2"
 
@@ -26,12 +26,14 @@ async-trait = { version = "0.1.42" }
 environmental = { version = "1.1.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 impl-trait-for-tuples = "0.2.1"
-parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-futures = { version = "0.3.24", features = [ "compat" ] }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
+futures = { version = "0.3.31", features = ["compat"] }
 log = { version = "0.4.22", default-features = false }
 parking_lot = "0.12"
 scale-info = { version = "2.11.2", default-features = false, features = [
-	"derive",
+    "derive",
 ] }
 schnorrkel = { version = "0.11.4", default-features = false }
 serde = { version = "1.0.195", default-features = false }

--- a/pallets/async-backing/src/consensus_hook.rs
+++ b/pallets/async-backing/src/consensus_hook.rs
@@ -29,9 +29,6 @@ use frame_support::pallet_prelude::*;
 use sp_consensus_slots::Slot;
 use sp_std::{marker::PhantomData, num::NonZeroU32};
 
-#[cfg(tests)]
-type RelayChainStateProof = crate::mock::FakeRelayChainStateProof;
-
 /// A consensus hook for a fixed block processing velocity and unincluded segment capacity.
 ///
 /// Relay chain slot duration must be provided in milliseconds.

--- a/pallets/async-backing/src/mock.rs
+++ b/pallets/async-backing/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -22,14 +22,14 @@
 
 extern crate alloc;
 
+use alloc::string::String;
 use frame_support::traits::{FindAuthor, Get};
 use nimbus_primitives::{
 	AccountLookup, CanAuthor, NimbusId, SlotBeacon, INHERENT_IDENTIFIER, NIMBUS_ENGINE_ID,
 };
 use parity_scale_codec::{Decode, Encode, FullCodec};
 use sp_inherents::{InherentIdentifier, IsFatalError};
-use sp_runtime::{ConsensusEngineId, RuntimeString};
-use alloc::string::String;
+use sp_runtime::ConsensusEngineId;
 
 pub use crate::weights::WeightInfo;
 pub use exec::BlockExecutor;
@@ -163,11 +163,9 @@ pub mod pallet {
 		fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			// Return Ok(Some(_)) unconditionally because this inherent is required in every block
 			// If it is not found, throw an AuthorInherentRequired error.
-			Ok(Some(InherentError::Other(
-				String::from(
-					"Inherent required to manually initiate author validation",
-				),
-			)))
+			Ok(Some(InherentError::Other(String::from(
+				"Inherent required to manually initiate author validation",
+			))))
 		}
 
 		// Regardless of whether the client is still supplying the author id,
@@ -235,7 +233,7 @@ pub mod pallet {
 #[derive(Encode)]
 #[cfg_attr(feature = "std", derive(Debug, Decode))]
 pub enum InherentError {
-	Other(RuntimeString),
+	Other(String),
 }
 
 impl IsFatalError for InherentError {

--- a/pallets/author-inherent/src/mock.rs
+++ b/pallets/author-inherent/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -74,6 +74,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -121,6 +122,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/author-slot-filter/src/mock.rs
+++ b/pallets/author-slot-filter/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/emergency-para-xcm/src/mock.rs
+++ b/pallets/emergency-para-xcm/src/mock.rs
@@ -49,6 +49,7 @@ parameter_types! {
 pub type AccountId = u64;
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -97,6 +98,7 @@ impl cumulus_pallet_parachain_system::Config for Test {
 	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type WeightInfo = ();
 	type ConsensusHook = cumulus_pallet_parachain_system::ExpectParentIncluded;
+	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Test>;
 }
 
 parameter_types! {

--- a/pallets/foreign-asset-creator/src/mock.rs
+++ b/pallets/foreign-asset-creator/src/mock.rs
@@ -48,6 +48,7 @@ parameter_types! {
 	pub const BlockHashCount: u32 = 250;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -97,6 +98,7 @@ impl pallet_balances::Config for Test {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = MaintenanceMode;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -56,6 +56,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = RocksDbWeight;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -104,6 +105,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/randomness/src/lib.rs
+++ b/pallets/randomness/src/lib.rs
@@ -277,11 +277,9 @@ pub mod pallet {
 		fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			// Return Ok(Some(_)) unconditionally because this inherent is required in every block
 			// If it is not found, throw a VrfInherentRequired error.
-			Ok(Some(InherentError::Other(
-				String::from(
-					"Inherent required to set babe randomness results",
-				),
-			)))
+			Ok(Some(InherentError::Other(String::from(
+				"Inherent required to set babe randomness results",
+			))))
 		}
 
 		// The empty-payload inherent extrinsic.

--- a/pallets/randomness/src/mock.rs
+++ b/pallets/randomness/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -99,6 +100,7 @@ impl pallet_balances::Config for Test {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/relay-storage-roots/src/mock.rs
+++ b/pallets/relay-storage-roots/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Test {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub struct PersistedValidationDataGetter;

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -48,6 +48,10 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+/// System account size in bytes = Pallet_Name_Hash (16) + Storage_name_hash (16) +
+/// Blake2_128Concat (16) + AccountId (20) + AccountInfo (4 + 12 + AccountData (4* 16)) = 148
+pub const SYSTEM_ACCOUNT_SIZE: u64 = 148;
+
 /// Solidity selector of the Transfer log, which is the Keccak of the Log signature.
 pub const SELECTOR_LOG_TRANSFER: [u8; 32] = keccak256!("Transfer(address,address,uint256)");
 
@@ -257,7 +261,7 @@ where
 					id: asset_id.clone().into(),
 					delegate: Runtime::Lookup::unlookup(spender.clone()),
 				},
-                                0,
+				0,
 			)?;
 		}
 		// Dispatch call (if enough gas).
@@ -269,7 +273,7 @@ where
 				delegate: Runtime::Lookup::unlookup(spender),
 				amount,
 			},
-                        0,
+			0,
 		)?;
 
 		Ok(())
@@ -301,7 +305,7 @@ where
 					target: Runtime::Lookup::unlookup(to),
 					amount: value,
 				},
-                                0,
+				SYSTEM_ACCOUNT_SIZE,
 			)?;
 		}
 
@@ -349,7 +353,7 @@ where
 						destination: Runtime::Lookup::unlookup(to),
 						amount: value,
 					},
-                                        0,
+					SYSTEM_ACCOUNT_SIZE,
 				)?;
 			} else {
 				// Dispatch call (if enough gas).
@@ -361,7 +365,7 @@ where
 						target: Runtime::Lookup::unlookup(to),
 						amount: value,
 					},
-                                        0,
+					SYSTEM_ACCOUNT_SIZE,
 				)?;
 			}
 		}

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -83,6 +83,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -143,6 +144,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -189,7 +191,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -245,7 +245,7 @@ fn approve() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -286,7 +286,7 @@ fn approve_saturating() {
 						value: U256::MAX,
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -415,7 +415,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -542,7 +542,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(66146756) // 1 weight => 1 gas in mock
+				.expect_cost(70172756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -620,7 +620,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -643,7 +643,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 300.into(),
 					},
 				)
-				.expect_cost(65259756)
+				.expect_cost(76042756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -751,7 +751,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -898,7 +898,7 @@ fn permit_valid() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1007,7 +1007,7 @@ fn permit_valid_named_asset() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1485,7 +1485,7 @@ fn permit_valid_with_metamask_signed_data() {
 						s: H256::from(s_real),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(1u128),
 					SELECTOR_LOG_APPROVAL,

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -34,9 +34,11 @@ const PERMIT_DOMAIN: [u8; 32] = keccak256!(
 	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
-pub struct Eip2612<Runtime, Metadata, Instance = ()>(PhantomData<(Runtime, Metadata, Instance)>);
+pub struct Eip2612<Runtime, Metadata, StorageGrowth, Instance = ()>(
+	PhantomData<(Runtime, Metadata, StorageGrowth, Instance)>,
+);
 
-impl<Runtime, Metadata, Instance> Eip2612<Runtime, Metadata, Instance>
+impl<Runtime, Metadata, StorageGrowth, Instance> Eip2612<Runtime, Metadata, StorageGrowth, Instance>
 where
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -46,6 +48,7 @@ where
 	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
+	StorageGrowth: Get<u64>,
 {
 	pub fn compute_domain_separator(address: H160) -> [u8; 32] {
 		let name: H256 = keccak_256(Metadata::name().as_bytes()).into();
@@ -144,7 +147,7 @@ where
 
 		{
 			let amount =
-				Erc20BalancesPrecompile::<Runtime, Metadata, Instance>::u256_to_amount(value)
+				Erc20BalancesPrecompile::<Runtime, Metadata, StorageGrowth, Instance>::u256_to_amount(value)
 					.unwrap_or_else(|_| Bounded::max_value());
 
 			let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -21,6 +21,7 @@
 use fp_evm::PrecompileHandle;
 use frame_support::{
 	dispatch::{GetDispatchInfo, PostDispatchInfo},
+	pallet_prelude::Get,
 	sp_runtime::traits::{Bounded, CheckedSub, Dispatchable, StaticLookup},
 	storage::types::{StorageDoubleMap, StorageMap, ValueQuery},
 	traits::StorageInstance,
@@ -173,12 +174,16 @@ pub trait Erc20Metadata {
 /// Precompile exposing a pallet_balance as an ERC20.
 /// Multiple precompiles can support instances of pallet_balance.
 /// The precompile uses an additional storage to store approvals.
-pub struct Erc20BalancesPrecompile<Runtime, Metadata: Erc20Metadata, Instance: 'static = ()>(
-	PhantomData<(Runtime, Metadata, Instance)>,
-);
+pub struct Erc20BalancesPrecompile<
+	Runtime,
+	Metadata: Erc20Metadata,
+	StorageGrowth,
+	Instance: 'static = (),
+>(PhantomData<(Runtime, Metadata, StorageGrowth, Instance)>);
 
 #[precompile_utils::precompile]
-impl<Runtime, Metadata, Instance> Erc20BalancesPrecompile<Runtime, Metadata, Instance>
+impl<Runtime, Metadata, StorageGrowth, Instance>
+	Erc20BalancesPrecompile<Runtime, Metadata, StorageGrowth, Instance>
 where
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -188,6 +193,7 @@ where
 	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
+	StorageGrowth: Get<u64>,
 {
 	#[precompile::public("totalSupply()")]
 	#[precompile::view]
@@ -288,7 +294,7 @@ where
 					dest: Runtime::Lookup::unlookup(to),
 					value: value,
 				},
-                                0,
+				StorageGrowth::get(),
 			)?;
 		}
 
@@ -354,7 +360,7 @@ where
 					dest: Runtime::Lookup::unlookup(to),
 					value: value,
 				},
-                                0,
+				StorageGrowth::get(),
 			)?;
 		}
 
@@ -416,7 +422,7 @@ where
 				dest: Runtime::Lookup::unlookup(caller),
 				value: amount,
 			},
-                        0,
+			StorageGrowth::get(),
 		)?;
 
 		log2(
@@ -471,7 +477,7 @@ where
 		r: H256,
 		s: H256,
 	) -> EvmResult {
-		<Eip2612<Runtime, Metadata, Instance>>::permit(
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::permit(
 			handle, owner, spender, value, deadline, v, r, s,
 		)
 	}
@@ -479,13 +485,13 @@ where
 	#[precompile::public("nonces(address)")]
 	#[precompile::view]
 	fn eip2612_nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
-		<Eip2612<Runtime, Metadata, Instance>>::nonces(handle, owner)
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::nonces(handle, owner)
 	}
 
 	#[precompile::public("DOMAIN_SEPARATOR()")]
 	#[precompile::view]
 	fn eip2612_domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-		<Eip2612<Runtime, Metadata, Instance>>::domain_separator(handle)
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::domain_separator(handle)
 	}
 
 	fn u256_to_amount(value: U256) -> MayRevert<BalanceOf<Runtime, Instance>> {

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
-use sp_core::{ConstU32, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
@@ -37,6 +37,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -97,14 +98,15 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
 	R,
-	(PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata>>,),
+	(PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata, ()>>,),
 >;
 
-pub type PCall = Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata, ()>;
+pub type PCall = Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata, (), ()>;
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
@@ -138,7 +140,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -280,7 +280,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -370,7 +370,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -466,7 +466,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -834,7 +834,7 @@ fn permit_valid() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 0u8.into(); // todo: proper timestamp
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,
@@ -921,7 +921,7 @@ fn permit_invalid_nonce() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 0u8.into();
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,
@@ -1068,7 +1068,7 @@ fn permit_invalid_deadline() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 5u8.into(); // deadline < timestamp => expired
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -153,7 +155,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -1008,7 +1008,7 @@ fn batch_not_callable_by_smart_contract() {
 		.execute_with(|| {
 			// "deploy" SC to alice address
 			let alice_h160: H160 = Alice.into();
-			pallet_evm::AccountCodes::<Runtime>::insert(alice_h160, vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(alice_h160, vec![10u8]);
 
 			// succeeds if not called by SC, see `evm_batch_recursion_under_limit`
 			let input = PCall::batch_all {
@@ -1049,7 +1049,7 @@ fn batch_is_not_callable_by_dummy_code() {
 		.execute_with(|| {
 			// "deploy" dummy code to alice address
 			let alice_h160: H160 = Alice.into();
-			pallet_evm::AccountCodes::<Runtime>::insert(
+			pallet_evm::Pallet::<Runtime>::create_account(
 				alice_h160,
 				[0x60, 0x00, 0x60, 0x00, 0xfd].to_vec(),
 			);

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 mock_account!(CallPermit, |_| MockAccount::from_u64(1));
@@ -139,7 +141,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/pallet-xcm/src/mock.rs
+++ b/precompiles/pallet-xcm/src/mock.rs
@@ -78,6 +78,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = MockDbWeight;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -125,6 +126,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 parameter_types! {
 	pub const AssetDeposit: u64 = 0;
@@ -271,7 +273,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -430,7 +430,7 @@ fn test_transfer_assets_using_type_and_then_location_no_remote_reserve() {
 			let destination_asset_location = Location::new(1, [Parachain(2), PalletInstance(3)]);
 			let origin_asset_location = Location::new(0, [PalletInstance(1)]);
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -472,7 +472,7 @@ fn test_transfer_assets_using_type_and_then_location_remote_reserve() {
 			let dest = Location::new(1, [Parachain(2)]);
 			let relay_asset_location = Location::parent();
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -513,7 +513,7 @@ fn test_transfer_assets_using_type_and_then_address_no_remote_reserve() {
 			// We send the native currency of the origin chain and pay fees with it.
 			let pallet_balances_address = H160::from_low_u64_be(2050);
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -557,7 +557,7 @@ fn test_transfer_assets_using_type_and_then_address_remote_reserve() {
 				H160::from_str("0xfFfFFFffFffFFFFffFFfFfffFfFFFFFfffFF0005").unwrap();
 
 			let dest = Location::new(1, [Parachain(2)]);
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -32,6 +32,10 @@ use sp_runtime::{
 };
 use sp_std::marker::PhantomData;
 
+/// System account size in bytes = Pallet_Name_Hash (16) + Storage_name_hash (16) +
+/// Blake2_128Concat (16) + AccountId (20) + AccountInfo (4 + 12 + AccountData (4* 16)) = 148
+pub const SYSTEM_ACCOUNT_SIZE: u64 = 148;
+
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
@@ -425,7 +429,7 @@ where
 						balance
 					},
 				},
-                                0,
+				SYSTEM_ACCOUNT_SIZE,
 			)?;
 
 			Some(Transfer {

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -30,7 +30,7 @@ use precompile_utils::{
 	testing::MockAccount,
 };
 use scale_info::TypeInfo;
-use sp_core::{ConstU32, H160, H256, U256};
+use sp_core::{H160, H256, U256};
 use sp_io;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_runtime::{
@@ -58,6 +58,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -105,6 +106,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -176,7 +178,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -578,7 +578,7 @@ fn fails_if_called_by_smart_contract() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice address as it if was a smart contract.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
 
 			PrecompilesValue::get()
 				.prepare_test(
@@ -776,8 +776,8 @@ fn proxy_proxy_should_fail_if_called_by_smart_contract_for_a_non_eoa_account() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice & Bob addresses as if they are smart contracts.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Bob), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Bob), vec![10u8]);
 
 			// Bob allows Alice to make calls on his behalf
 			assert_ok!(RuntimeCall::Proxy(ProxyCall::add_proxy {

--- a/precompiles/xcm-utils/src/lib.rs
+++ b/precompiles/xcm-utils/src/lib.rs
@@ -22,6 +22,7 @@ use fp_evm::PrecompileHandle;
 use frame_support::traits::ConstU32;
 use frame_support::{
 	dispatch::{GetDispatchInfo, PostDispatchInfo},
+	pallet_prelude::Get,
 	traits::OriginTrait,
 };
 use pallet_evm::AddressMapping;
@@ -58,14 +59,18 @@ mod mock;
 mod tests;
 
 #[derive(Debug)]
-pub struct AllExceptXcmExecute<Runtime, XcmConfig>(PhantomData<(Runtime, XcmConfig)>);
+pub struct AllExceptXcmExecute<Runtime, XcmConfig, StorageGrowth>(
+	PhantomData<(Runtime, XcmConfig, StorageGrowth)>,
+);
 
-impl<Runtime, XcmConfig> SelectorFilter for AllExceptXcmExecute<Runtime, XcmConfig>
+impl<Runtime, XcmConfig, StorageGrowth> SelectorFilter
+	for AllExceptXcmExecute<Runtime, XcmConfig, StorageGrowth>
 where
 	Runtime: pallet_evm::Config + frame_system::Config + pallet_xcm::Config,
 	XcmOriginOf<XcmConfig>: OriginTrait,
 	XcmAccountIdOf<XcmConfig>: Into<H160>,
 	XcmConfig: xcm_executor::Config,
+	StorageGrowth: Get<u64>,
 	<Runtime as frame_system::Config>::RuntimeCall:
 		Dispatchable<PostInfo = PostDispatchInfo> + Decode + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
@@ -77,8 +82,9 @@ where
 		match selector {
 			None => true,
 			Some(selector) => {
-				!XcmUtilsPrecompileCall::<Runtime, XcmConfig>::xcm_execute_selectors()
-					.contains(&selector)
+				!XcmUtilsPrecompileCall::<Runtime, XcmConfig, StorageGrowth>::xcm_execute_selectors(
+				)
+				.contains(&selector)
 			}
 		}
 	}
@@ -89,15 +95,18 @@ where
 }
 
 /// A precompile to wrap the functionality from xcm-utils
-pub struct XcmUtilsPrecompile<Runtime, XcmConfig>(PhantomData<(Runtime, XcmConfig)>);
+pub struct XcmUtilsPrecompile<Runtime, XcmConfig, StorageGrowth>(
+	PhantomData<(Runtime, XcmConfig, StorageGrowth)>,
+);
 
 #[precompile_utils::precompile]
-impl<Runtime, XcmConfig> XcmUtilsPrecompile<Runtime, XcmConfig>
+impl<Runtime, XcmConfig, StorageGrowth> XcmUtilsPrecompile<Runtime, XcmConfig, StorageGrowth>
 where
 	Runtime: pallet_evm::Config + frame_system::Config + pallet_xcm::Config,
 	XcmOriginOf<XcmConfig>: OriginTrait,
 	XcmAccountIdOf<XcmConfig>: Into<H160>,
 	XcmConfig: xcm_executor::Config,
+	StorageGrowth: Get<u64>,
 	<Runtime as frame_system::Config>::RuntimeCall:
 		Dispatchable<PostInfo = PostDispatchInfo> + Decode + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
@@ -224,7 +233,12 @@ where
 			max_weight: Weight::from_parts(weight, DEFAULT_PROOF_SIZE),
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			StorageGrowth::get(),
+		)?;
 
 		Ok(())
 	}
@@ -251,7 +265,12 @@ where
 			message: Box::new(xcm),
 		};
 
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call, 0)?;
+		RuntimeHelper::<Runtime>::try_dispatch(
+			handle,
+			Some(origin).into(),
+			call,
+			StorageGrowth::get(),
+		)?;
 
 		Ok(())
 	}

--- a/precompiles/xcm-utils/src/tests.rs
+++ b/precompiles/xcm-utils/src/tests.rs
@@ -86,7 +86,7 @@ fn test_get_account_sibling() {
 #[test]
 fn test_weight_message() {
 	ExtBuilder::default().build().execute_with(|| {
-		let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::weight_message {
 			message: message.into(),
@@ -118,7 +118,7 @@ fn test_get_units_per_second() {
 #[test]
 fn test_executor_clear_origin() {
 	ExtBuilder::default().build().execute_with(|| {
-		let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::xcm_execute {
 			message: xcm_to_execute.into(),
@@ -137,7 +137,7 @@ fn test_executor_clear_origin() {
 fn test_executor_send() {
 	ExtBuilder::default().build().execute_with(|| {
 		let withdrawn_asset: Asset = (Location::parent(), 1u128).into();
-		let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![
+		let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![
 			WithdrawAsset(vec![withdrawn_asset].into()),
 			InitiateReserveWithdraw {
 				assets: AssetFilter::Wild(All),
@@ -184,9 +184,9 @@ fn test_executor_transact() {
 			}
 			.encode();
 			encoded.append(&mut call_bytes);
-			let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![Transact {
+			let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![Transact {
 				origin_kind: OriginKind::SovereignAccount,
-				require_weight_at_most: Weight::from_parts(1_000_000_000u64, 5206u64),
+				fallback_max_weight: Some(Weight::from_parts(1_000_000_000u64, 5206u64)),
 				call: encoded.into(),
 			}]))
 			.encode();
@@ -198,7 +198,7 @@ fn test_executor_transact() {
 
 			precompiles()
 				.prepare_test(CryptoAlith, Precompile1, input)
-				.expect_cost(1100001001)
+				.expect_cost(276106001)
 				.expect_no_logs()
 				.execute_returns(());
 
@@ -211,7 +211,7 @@ fn test_executor_transact() {
 #[test]
 fn test_send_clear_origin() {
 	ExtBuilder::default().build().execute_with(|| {
-		let xcm_to_send = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let xcm_to_send = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::xcm_send {
 			dest: Location::parent(),
@@ -242,9 +242,9 @@ fn execute_fails_if_called_by_smart_contract() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice address as it if was a smart contract.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
 
-			let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			let input = PCall::xcm_execute {
 				message: xcm_to_execute.into(),

--- a/primitives/session-keys/src/inherent.rs
+++ b/primitives/session-keys/src/inherent.rs
@@ -13,14 +13,16 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+extern crate alloc;
+
+use alloc::string::String;
 use parity_scale_codec::{Decode, Encode};
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_runtime::RuntimeString;
 
 #[derive(Encode)]
 #[cfg_attr(feature = "std", derive(Debug, Decode))]
 pub enum InherentError {
-	Other(RuntimeString),
+	Other(String),
 }
 
 impl IsFatalError for InherentError {

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -23,11 +23,13 @@ use cumulus_primitives_core::CollectCollationInfo;
 use cumulus_client_service::{
 	prepare_node_config, start_relay_chain_tasks, DARecoveryProfile, StartRelayChainTasksParams,
 };
+use cumulus_primitives_core::CollectCollationInfo;
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node_with_rpc;
 
+use polkadot_primitives::UpgradeGoAhead;
 use polkadot_service::CollatorPair;
 use polkadot_primitives::UpgradeGoAhead;
 
@@ -191,8 +193,9 @@ async fn build_relay_chain_interface(
 	{
 		build_minimal_relay_chain_node_with_rpc(polkadot_config,
                     parachain_config.prometheus_registry(),
-                    task_manager, rpc_target_urls)
-			.await
+                    task_manager, rpc_target_urls,
+		)
+		.await
 	} else {
 		build_inprocess_relay_chain(
 			polkadot_config,

--- a/template/pallets/template/src/mock.rs
+++ b/template/pallets/template/src/mock.rs
@@ -24,6 +24,7 @@ parameter_types! {
 }
 
 impl system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -10,11 +10,10 @@ use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU32, OpaqueMetadata};
 use sp_runtime::{
-    Cow,
 	generic, impl_opaque_keys,
 	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+	ApplyExtrinsicResult, Cow, MultiSignature,
 };
 
 pub use nimbus_primitives::NimbusId;
@@ -348,7 +347,7 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
-        type ExtensionsWeightInfo = ();
+    type ExtensionsWeightInfo = ();
 }
 
 parameter_types! {
@@ -385,7 +384,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ConstU32<0>;
-        type DoneSlashHandler = ();
+    type DoneSlashHandler = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
Cherry pick from [upstream](https://github.com/Moonsong-Labs/moonkit/pull/59/commits/3f61599b0716dd77a78cd761589f098f023c9d9d)

* feat: :arrow_up: upgrade to polkadot-sdk 2412

* fix: :bug: fix compilation errors

* chore: :arrow_up: upgrade frontier in lock file

* test: :white_check_mark: update expected_cost

* test: :white_check_mark: update more expected_costs

* test: :white_check_mark: fix more expected costs

* refactor: :coffin: remove dead code

* use storage growth in precompiles (mbip-5)

* refactor: :rotating_light: lint/fmt

* fix: tests to also create account metadata

* improve async backing logs