### PR TITLE
Cherry pick from upstream repo (to main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
@@ -1723,7 +1723,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "dyn-clone",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -1765,7 +1765,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -1814,7 +1814,7 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -1847,7 +1847,7 @@ dependencies = [
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
@@ -2031,7 +2031,7 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-cli",
  "polkadot-service",
@@ -2054,7 +2054,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee-core",
  "parity-scale-codec",
  "polkadot-overseer",
@@ -2076,7 +2076,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-network-protocol",
@@ -2110,7 +2110,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "parity-scale-codec",
@@ -2880,7 +2880,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
 ]
 
 [[package]]
@@ -3020,7 +3020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "num-traits",
@@ -3524,9 +3524,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3549,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3559,15 +3559,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3577,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -3611,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3632,15 +3632,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -3650,9 +3650,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -3774,7 +3774,7 @@ checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
  "dashmap",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
@@ -4218,7 +4218,7 @@ dependencies = [
  "async-io 2.3.1",
  "core-foundation",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "if-addrs",
  "ipnet",
  "log",
@@ -4237,7 +4237,7 @@ dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "http 0.2.11",
  "hyper 0.14.30",
  "log",
@@ -4725,7 +4725,7 @@ checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
 dependencies = [
  "bytes",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "getrandom",
  "instant",
@@ -4786,7 +4786,7 @@ checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-identity",
@@ -4813,7 +4813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
  "log",
@@ -4830,7 +4830,7 @@ checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
 dependencies = [
  "asynchronous-codec",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-bounded",
  "futures-timer",
  "libp2p-core",
@@ -4874,7 +4874,7 @@ dependencies = [
  "bytes",
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4899,7 +4899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
 dependencies = [
  "data-encoding",
- "futures 0.3.30",
+ "futures 0.3.31",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -4938,7 +4938,7 @@ checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
 dependencies = [
  "bytes",
  "curve25519-dalek",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
  "log",
@@ -4962,7 +4962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -4980,7 +4980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libp2p-core",
@@ -5004,7 +5004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "instant",
  "libp2p-core",
  "libp2p-identity",
@@ -5023,7 +5023,7 @@ checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -5057,7 +5057,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libc",
@@ -5074,7 +5074,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
@@ -5093,7 +5093,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "igd-next",
  "libp2p-core",
@@ -5109,7 +5109,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "js-sys",
  "libp2p-core",
  "send_wrapper",
@@ -5124,7 +5124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
@@ -5144,7 +5144,7 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "log",
  "thiserror",
@@ -5310,7 +5310,7 @@ dependencies = [
  "bytes",
  "cid 0.10.1",
  "ed25519-dalek",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "hex-literal",
  "indexmap 2.2.3",
@@ -5585,7 +5585,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "rand",
  "thrift",
 ]
@@ -5646,7 +5646,7 @@ name = "mmr-gadget"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -5750,7 +5750,7 @@ dependencies = [
  "flume",
  "frame-benchmarking",
  "frame-benchmarking-cli",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex-literal",
  "jsonrpsee",
  "log",
@@ -5978,7 +5978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "pin-project",
  "smallvec",
@@ -6075,7 +6075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -6090,7 +6090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libc",
  "log",
  "tokio",
@@ -6121,7 +6121,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "nimbus-primitives",
  "parity-scale-codec",
@@ -6340,7 +6340,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.85",
@@ -6471,7 +6471,7 @@ checksum = "41f6bbacc8c189a3f2e45e0fd0436e5d97f194db888e721bdbc3973e7dbed4c2"
 dependencies = [
  "async-trait",
  "dyn-clonable",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "orchestra-proc-macro",
  "pin-project",
@@ -8393,7 +8393,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "bitvec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
  "polkadot-node-jaeger",
@@ -8413,7 +8413,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "always-assert",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -8430,7 +8430,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "derive_more",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8454,7 +8454,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "async-trait",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8488,7 +8488,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "frame-benchmarking-cli",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
@@ -8515,7 +8515,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -8549,7 +8549,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "derive_more",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "indexmap 2.2.3",
  "parity-scale-codec",
@@ -8586,7 +8586,7 @@ name = "polkadot-gossip-support"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -8612,7 +8612,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-metrics",
@@ -8631,7 +8631,7 @@ name = "polkadot-node-collation-generation"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
@@ -8651,7 +8651,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "bitvec",
  "derive_more",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
  "kvdb",
@@ -8683,7 +8683,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "bitvec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -8706,7 +8706,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -8724,7 +8724,7 @@ name = "polkadot-node-core-bitfield-signing"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -8740,7 +8740,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
@@ -8761,7 +8761,7 @@ name = "polkadot-node-core-chain-api"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
@@ -8775,7 +8775,7 @@ name = "polkadot-node-core-chain-selection"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -8793,7 +8793,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -8812,7 +8812,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
@@ -8829,7 +8829,7 @@ version = "17.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -8844,7 +8844,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -8864,7 +8864,7 @@ dependencies = [
  "array-bytes",
  "blake3",
  "cfg-if",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
@@ -8889,7 +8889,7 @@ name = "polkadot-node-core-pvf-checker"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -8906,7 +8906,7 @@ version = "16.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "cpu-time",
- "futures 0.3.30",
+ "futures 0.3.31",
  "landlock",
  "libc",
  "nix 0.28.0",
@@ -8931,7 +8931,7 @@ name = "polkadot-node-core-runtime-api"
 version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
@@ -8966,7 +8966,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "bs58 0.5.1",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -8989,7 +8989,7 @@ dependencies = [
  "bitvec",
  "derive_more",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex",
  "parity-scale-codec",
  "polkadot-node-jaeger",
@@ -9012,7 +9012,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "bitvec",
  "bounded-vec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
@@ -9050,7 +9050,7 @@ dependencies = [
  "bitvec",
  "derive_more",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "orchestra",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
@@ -9079,7 +9079,7 @@ dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-channel",
  "itertools 0.11.0",
  "kvdb",
@@ -9113,7 +9113,7 @@ version = "18.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "orchestra",
  "parking_lot 0.12.3",
@@ -9327,7 +9327,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "futures 0.3.30",
+ "futures 0.3.31",
  "is_executable",
  "kvdb",
  "kvdb-rocksdb",
@@ -9432,7 +9432,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "indexmap 2.2.3",
  "parity-scale-codec",
@@ -9748,7 +9748,7 @@ dependencies = [
  "coarsetime",
  "crossbeam-queue",
  "derive_more",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "nanorand",
  "thiserror",
@@ -10583,7 +10583,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "netlink-packet-route",
  "netlink-proto",
@@ -10853,7 +10853,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "pin-project",
  "static_assertions",
 ]
@@ -10908,7 +10908,7 @@ version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "ip_network",
  "libp2p",
@@ -10937,7 +10937,7 @@ name = "sc-basic-authorship"
 version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -11016,7 +11016,7 @@ dependencies = [
  "chrono",
  "clap",
  "fdlimit",
- "futures 0.3.30",
+ "futures 0.3.31",
  "itertools 0.11.0",
  "libp2p-identity",
  "log",
@@ -11054,7 +11054,7 @@ version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11107,7 +11107,7 @@ version = "0.44.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "mockall 0.11.4",
  "parking_lot 0.12.3",
@@ -11131,7 +11131,7 @@ version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -11161,7 +11161,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "async-trait",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "num-bigint",
  "num-rational",
@@ -11195,7 +11195,7 @@ name = "sc-consensus-babe-rpc"
 version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
@@ -11221,7 +11221,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -11253,7 +11253,7 @@ name = "sc-consensus-beefy-rpc"
 version = "24.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -11292,7 +11292,7 @@ dependencies = [
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -11331,7 +11331,7 @@ version = "0.30.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "finality-grandpa",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -11352,7 +11352,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "assert_matches",
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "log",
@@ -11386,7 +11386,7 @@ version = "0.44.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -11474,7 +11474,7 @@ version = "0.44.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "console",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "sc-client-api",
@@ -11508,7 +11508,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "blake2 0.10.6",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "mixnet",
@@ -11541,7 +11541,7 @@ dependencies = [
  "cid 0.9.0",
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "ip_network",
  "libp2p",
@@ -11586,7 +11586,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-identity",
  "parity-scale-codec",
  "prost-build 0.12.6",
@@ -11603,7 +11603,7 @@ version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "ahash",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "sc-network",
@@ -11623,7 +11623,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
@@ -11646,7 +11646,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "libp2p",
  "log",
@@ -11680,7 +11680,7 @@ version = "0.44.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "array-bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-network",
@@ -11718,7 +11718,7 @@ dependencies = [
  "array-bytes",
  "bytes",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "hyper 0.14.30",
  "hyper-rustls",
@@ -11758,7 +11758,7 @@ name = "sc-rpc"
 version = "40.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -11812,7 +11812,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
- "futures 0.3.30",
+ "futures 0.3.31",
  "governor",
  "http 1.1.0",
  "http-body-util",
@@ -11835,7 +11835,7 @@ version = "0.45.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "array-bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-util",
  "hex",
  "jsonrpsee",
@@ -11869,7 +11869,7 @@ dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "log",
@@ -11974,7 +11974,7 @@ version = "38.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "derive_more",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libc",
  "log",
  "rand",
@@ -11995,7 +11995,7 @@ version = "25.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "chrono",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p",
  "log",
  "parking_lot 0.12.3",
@@ -12055,7 +12055,7 @@ version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "linked-hash-map",
  "log",
@@ -12082,7 +12082,7 @@ version = "37.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "serde",
@@ -12098,7 +12098,7 @@ version = "17.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-channel 1.9.0",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "lazy_static",
  "log",
@@ -12825,7 +12825,7 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.1",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "httparse",
  "log",
  "rand",
@@ -12840,7 +12840,7 @@ checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
 dependencies = [
  "base64 0.22.0",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "http 1.1.0",
  "httparse",
  "log",
@@ -12937,7 +12937,7 @@ name = "sp-blockchain"
 version = "37.0.1"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
@@ -12957,7 +12957,7 @@ version = "0.40.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "sp-core",
  "sp-inherents",
@@ -13061,7 +13061,7 @@ dependencies = [
  "bs58 0.5.1",
  "dyn-clonable",
  "ed25519-zebra",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hash-db",
  "hash256-std-hasher",
  "impl-serde",
@@ -13851,7 +13851,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -13902,7 +13902,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0
 dependencies = [
  "array-bytes",
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "sc-client-api",
  "sc-client-db",
@@ -13971,7 +13971,7 @@ name = "substrate-test-runtime-client"
 version = "2.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2409#835e0767fe81355c7559e12802b977f96ca271d8"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -15090,7 +15090,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -15947,7 +15947,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
-	"client/consensus/nimbus-consensus",
-	"precompiles/*",
-	"pallets/*",
-	"primitives/*",
-	"template/node",
-	"template/runtime",
-	"template/pallets/template",
+    "client/consensus/nimbus-consensus",
+    "precompiles/*",
+    "pallets/*",
+    "primitives/*",
+    "template/node",
+    "template/runtime",
+    "template/pallets/template",
 ]
 resolver = "2"
 
@@ -26,12 +26,14 @@ async-trait = { version = "0.1.42" }
 environmental = { version = "1.1.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 impl-trait-for-tuples = "0.2.1"
-parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-futures = { version = "0.3.24", features = [ "compat" ] }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
+futures = { version = "0.3.31", features = ["compat"] }
 log = { version = "0.4.22", default-features = false }
 parking_lot = "0.12"
 scale-info = { version = "2.11.2", default-features = false, features = [
-	"derive",
+    "derive",
 ] }
 schnorrkel = { version = "0.11.4", default-features = false }
 serde = { version = "1.0.195", default-features = false }

--- a/pallets/async-backing/src/consensus_hook.rs
+++ b/pallets/async-backing/src/consensus_hook.rs
@@ -29,9 +29,6 @@ use frame_support::pallet_prelude::*;
 use sp_consensus_slots::Slot;
 use sp_std::{marker::PhantomData, num::NonZeroU32};
 
-#[cfg(tests)]
-type RelayChainStateProof = crate::mock::FakeRelayChainStateProof;
-
 /// A consensus hook for a fixed block processing velocity and unincluded segment capacity.
 ///
 /// Relay chain slot duration must be provided in milliseconds.

--- a/pallets/async-backing/src/mock.rs
+++ b/pallets/async-backing/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -163,9 +163,11 @@ pub mod pallet {
 		fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			// Return Ok(Some(_)) unconditionally because this inherent is required in every block
 			// If it is not found, throw an AuthorInherentRequired error.
-			Ok(Some(InherentError::Other(sp_runtime::RuntimeString::Borrowed(
-				"Inherent required to manually initiate author validation",
-			))))
+			Ok(Some(InherentError::Other(
+				sp_runtime::RuntimeString::Borrowed(
+					"Inherent required to manually initiate author validation",
+				),
+			)))
 		}
 
 		// Regardless of whether the client is still supplying the author id,

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -20,13 +20,16 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+use alloc::string::String;
 use frame_support::traits::{FindAuthor, Get};
 use nimbus_primitives::{
 	AccountLookup, CanAuthor, NimbusId, SlotBeacon, INHERENT_IDENTIFIER, NIMBUS_ENGINE_ID,
 };
 use parity_scale_codec::{Decode, Encode, FullCodec};
 use sp_inherents::{InherentIdentifier, IsFatalError};
-use sp_runtime::{ConsensusEngineId, RuntimeString};
+use sp_runtime::ConsensusEngineId;
 
 pub use crate::weights::WeightInfo;
 pub use exec::BlockExecutor;
@@ -160,11 +163,9 @@ pub mod pallet {
 		fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			// Return Ok(Some(_)) unconditionally because this inherent is required in every block
 			// If it is not found, throw an AuthorInherentRequired error.
-			Ok(Some(InherentError::Other(
-				sp_runtime::RuntimeString::Borrowed(
-					"Inherent required to manually initiate author validation",
-				),
-			)))
+			Ok(Some(InherentError::Other(sp_runtime::RuntimeString::Borrowed(
+				"Inherent required to manually initiate author validation",
+			))))
 		}
 
 		// Regardless of whether the client is still supplying the author id,
@@ -232,7 +233,7 @@ pub mod pallet {
 #[derive(Encode)]
 #[cfg_attr(feature = "std", derive(Debug, Decode))]
 pub enum InherentError {
-	Other(RuntimeString),
+	Other(String),
 }
 
 impl IsFatalError for InherentError {

--- a/pallets/author-inherent/src/mock.rs
+++ b/pallets/author-inherent/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -74,6 +74,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -121,6 +122,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/author-slot-filter/src/mock.rs
+++ b/pallets/author-slot-filter/src/mock.rs
@@ -45,6 +45,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/pallets/emergency-para-xcm/src/mock.rs
+++ b/pallets/emergency-para-xcm/src/mock.rs
@@ -49,6 +49,7 @@ parameter_types! {
 pub type AccountId = u64;
 
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = frame_support::traits::Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -97,6 +98,7 @@ impl cumulus_pallet_parachain_system::Config for Test {
 	type CheckAssociatedRelayNumber = EmergencyParaXcm;
 	type WeightInfo = ();
 	type ConsensusHook = cumulus_pallet_parachain_system::ExpectParentIncluded;
+	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Test>;
 }
 
 parameter_types! {

--- a/pallets/foreign-asset-creator/src/mock.rs
+++ b/pallets/foreign-asset-creator/src/mock.rs
@@ -48,6 +48,7 @@ parameter_types! {
 	pub const BlockHashCount: u32 = 250;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -97,6 +98,7 @@ impl pallet_balances::Config for Test {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = MaintenanceMode;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -56,6 +56,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = RocksDbWeight;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -104,6 +105,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/randomness/src/mock.rs
+++ b/pallets/randomness/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -99,6 +100,7 @@ impl pallet_balances::Config for Test {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/relay-storage-roots/src/mock.rs
+++ b/pallets/relay-storage-roots/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Test {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub struct PersistedValidationDataGetter;

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -48,6 +48,10 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+/// System account size in bytes = Pallet_Name_Hash (16) + Storage_name_hash (16) +
+/// Blake2_128Concat (16) + AccountId (20) + AccountInfo (4 + 12 + AccountData (4* 16)) = 148
+pub const SYSTEM_ACCOUNT_SIZE: u64 = 148;
+
 /// Solidity selector of the Transfer log, which is the Keccak of the Log signature.
 pub const SELECTOR_LOG_TRANSFER: [u8; 32] = keccak256!("Transfer(address,address,uint256)");
 
@@ -257,6 +261,7 @@ where
 					id: asset_id.clone().into(),
 					delegate: Runtime::Lookup::unlookup(spender.clone()),
 				},
+				0,
 			)?;
 		}
 		// Dispatch call (if enough gas).
@@ -268,6 +273,7 @@ where
 				delegate: Runtime::Lookup::unlookup(spender),
 				amount,
 			},
+			0,
 		)?;
 
 		Ok(())
@@ -299,6 +305,7 @@ where
 					target: Runtime::Lookup::unlookup(to),
 					amount: value,
 				},
+				SYSTEM_ACCOUNT_SIZE,
 			)?;
 		}
 
@@ -346,6 +353,7 @@ where
 						destination: Runtime::Lookup::unlookup(to),
 						amount: value,
 					},
+					SYSTEM_ACCOUNT_SIZE,
 				)?;
 			} else {
 				// Dispatch call (if enough gas).
@@ -357,6 +365,7 @@ where
 						target: Runtime::Lookup::unlookup(to),
 						amount: value,
 					},
+					SYSTEM_ACCOUNT_SIZE,
 				)?;
 			}
 		}

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -83,6 +83,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -143,6 +144,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -189,7 +191,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -245,7 +245,7 @@ fn approve() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -286,7 +286,7 @@ fn approve_saturating() {
 						value: U256::MAX,
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -415,7 +415,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -542,7 +542,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(66146756) // 1 weight => 1 gas in mock
+				.expect_cost(70172756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -620,7 +620,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(31625756)
+				.expect_cost(37024756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -643,7 +643,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 300.into(),
 					},
 				)
-				.expect_cost(65259756)
+				.expect_cost(76042756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -751,7 +751,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(44795756) // 1 weight => 1 gas in mock
+				.expect_cost(50509756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -898,7 +898,7 @@ fn permit_valid() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1007,7 +1007,7 @@ fn permit_valid_named_asset() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1485,7 +1485,7 @@ fn permit_valid_with_metamask_signed_data() {
 						s: H256::from(s_real),
 					},
 				)
-				.expect_cost(31624000)
+				.expect_cost(37023000)
 				.expect_log(log3(
 					ForeignAssetId(1u128),
 					SELECTOR_LOG_APPROVAL,

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -34,9 +34,11 @@ const PERMIT_DOMAIN: [u8; 32] = keccak256!(
 	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
-pub struct Eip2612<Runtime, Metadata, Instance = ()>(PhantomData<(Runtime, Metadata, Instance)>);
+pub struct Eip2612<Runtime, Metadata, StorageGrowth, Instance = ()>(
+	PhantomData<(Runtime, Metadata, StorageGrowth, Instance)>,
+);
 
-impl<Runtime, Metadata, Instance> Eip2612<Runtime, Metadata, Instance>
+impl<Runtime, Metadata, StorageGrowth, Instance> Eip2612<Runtime, Metadata, StorageGrowth, Instance>
 where
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -46,6 +48,7 @@ where
 	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
+	StorageGrowth: Get<u64>,
 {
 	pub fn compute_domain_separator(address: H160) -> [u8; 32] {
 		let name: H256 = keccak_256(Metadata::name().as_bytes()).into();
@@ -144,7 +147,7 @@ where
 
 		{
 			let amount =
-				Erc20BalancesPrecompile::<Runtime, Metadata, Instance>::u256_to_amount(value)
+				Erc20BalancesPrecompile::<Runtime, Metadata, StorageGrowth, Instance>::u256_to_amount(value)
 					.unwrap_or_else(|_| Bounded::max_value());
 
 			let owner: Runtime::AccountId = Runtime::AddressMapping::into_account_id(owner);

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -21,6 +21,7 @@
 use fp_evm::PrecompileHandle;
 use frame_support::{
 	dispatch::{GetDispatchInfo, PostDispatchInfo},
+	pallet_prelude::Get,
 	sp_runtime::traits::{Bounded, CheckedSub, Dispatchable, StaticLookup},
 	storage::types::{StorageDoubleMap, StorageMap, ValueQuery},
 	traits::StorageInstance,
@@ -173,12 +174,16 @@ pub trait Erc20Metadata {
 /// Precompile exposing a pallet_balance as an ERC20.
 /// Multiple precompiles can support instances of pallet_balance.
 /// The precompile uses an additional storage to store approvals.
-pub struct Erc20BalancesPrecompile<Runtime, Metadata: Erc20Metadata, Instance: 'static = ()>(
-	PhantomData<(Runtime, Metadata, Instance)>,
-);
+pub struct Erc20BalancesPrecompile<
+	Runtime,
+	Metadata: Erc20Metadata,
+	StorageGrowth,
+	Instance: 'static = (),
+>(PhantomData<(Runtime, Metadata, StorageGrowth, Instance)>);
 
 #[precompile_utils::precompile]
-impl<Runtime, Metadata, Instance> Erc20BalancesPrecompile<Runtime, Metadata, Instance>
+impl<Runtime, Metadata, StorageGrowth, Instance>
+	Erc20BalancesPrecompile<Runtime, Metadata, StorageGrowth, Instance>
 where
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -188,6 +193,7 @@ where
 	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
+	StorageGrowth: Get<u64>,
 {
 	#[precompile::public("totalSupply()")]
 	#[precompile::view]
@@ -288,6 +294,7 @@ where
 					dest: Runtime::Lookup::unlookup(to),
 					value: value,
 				},
+				StorageGrowth::get(),
 			)?;
 		}
 
@@ -353,6 +360,7 @@ where
 					dest: Runtime::Lookup::unlookup(to),
 					value: value,
 				},
+				StorageGrowth::get(),
 			)?;
 		}
 
@@ -414,6 +422,7 @@ where
 				dest: Runtime::Lookup::unlookup(caller),
 				value: amount,
 			},
+			StorageGrowth::get(),
 		)?;
 
 		log2(
@@ -468,7 +477,7 @@ where
 		r: H256,
 		s: H256,
 	) -> EvmResult {
-		<Eip2612<Runtime, Metadata, Instance>>::permit(
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::permit(
 			handle, owner, spender, value, deadline, v, r, s,
 		)
 	}
@@ -476,13 +485,13 @@ where
 	#[precompile::public("nonces(address)")]
 	#[precompile::view]
 	fn eip2612_nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
-		<Eip2612<Runtime, Metadata, Instance>>::nonces(handle, owner)
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::nonces(handle, owner)
 	}
 
 	#[precompile::public("DOMAIN_SEPARATOR()")]
 	#[precompile::view]
 	fn eip2612_domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
-		<Eip2612<Runtime, Metadata, Instance>>::domain_separator(handle)
+		<Eip2612<Runtime, Metadata, StorageGrowth, Instance>>::domain_separator(handle)
 	}
 
 	fn u256_to_amount(value: U256) -> MayRevert<BalanceOf<Runtime, Instance>> {

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
-use sp_core::{ConstU32, H256, U256};
+use sp_core::{H256, U256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	BuildStorage,
@@ -37,6 +37,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -97,14 +98,15 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
 	R,
-	(PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata>>,),
+	(PrecompileAt<AddressU64<1>, Erc20BalancesPrecompile<R, NativeErc20Metadata, ()>>,),
 >;
 
-pub type PCall = Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata, ()>;
+pub type PCall = Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata, (), ()>;
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 
@@ -138,7 +140,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -280,7 +280,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -370,7 +370,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -466,7 +466,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(173364756) // 1 weight => 1 gas in mock
+				.expect_cost(176106756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -834,7 +834,7 @@ fn permit_valid() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 0u8.into(); // todo: proper timestamp
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,
@@ -921,7 +921,7 @@ fn permit_invalid_nonce() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 0u8.into();
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,
@@ -1068,7 +1068,7 @@ fn permit_invalid_deadline() {
 			let value: U256 = 500u16.into();
 			let deadline: U256 = 5u8.into(); // deadline < timestamp => expired
 
-			let permit = Eip2612::<Runtime, NativeErc20Metadata>::generate_permit(
+			let permit = Eip2612::<Runtime, NativeErc20Metadata, ()>::generate_permit(
 				Precompile1.into(),
 				owner,
 				spender,

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -153,7 +155,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -1008,7 +1008,7 @@ fn batch_not_callable_by_smart_contract() {
 		.execute_with(|| {
 			// "deploy" SC to alice address
 			let alice_h160: H160 = Alice.into();
-			pallet_evm::AccountCodes::<Runtime>::insert(alice_h160, vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(alice_h160, vec![10u8]);
 
 			// succeeds if not called by SC, see `evm_batch_recursion_under_limit`
 			let input = PCall::batch_all {
@@ -1049,7 +1049,7 @@ fn batch_is_not_callable_by_dummy_code() {
 		.execute_with(|| {
 			// "deploy" dummy code to alice address
 			let alice_h160: H160 = Alice.into();
-			pallet_evm::AccountCodes::<Runtime>::insert(
+			pallet_evm::Pallet::<Runtime>::create_account(
 				alice_h160,
 				[0x60, 0x00, 0x60, 0x00, 0xfd].to_vec(),
 			);

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 mock_account!(CallPermit, |_| MockAccount::from_u64(1));
@@ -139,7 +141,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/pallet-xcm/src/mock.rs
+++ b/precompiles/pallet-xcm/src/mock.rs
@@ -78,6 +78,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = MockDbWeight;
 	type RuntimeOrigin = RuntimeOrigin;
@@ -125,6 +126,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 parameter_types! {
 	pub const AssetDeposit: u64 = 0;
@@ -271,7 +273,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/pallet-xcm/src/tests.rs
+++ b/precompiles/pallet-xcm/src/tests.rs
@@ -430,7 +430,7 @@ fn test_transfer_assets_using_type_and_then_location_no_remote_reserve() {
 			let destination_asset_location = Location::new(1, [Parachain(2), PalletInstance(3)]);
 			let origin_asset_location = Location::new(0, [PalletInstance(1)]);
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -472,7 +472,7 @@ fn test_transfer_assets_using_type_and_then_location_remote_reserve() {
 			let dest = Location::new(1, [Parachain(2)]);
 			let relay_asset_location = Location::parent();
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -513,7 +513,7 @@ fn test_transfer_assets_using_type_and_then_address_no_remote_reserve() {
 			// We send the native currency of the origin chain and pay fees with it.
 			let pallet_balances_address = H160::from_low_u64_be(2050);
 
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(
@@ -557,7 +557,7 @@ fn test_transfer_assets_using_type_and_then_address_remote_reserve() {
 				H160::from_str("0xfFfFFFffFffFFFFffFFfFfffFfFFFFFfffFF0005").unwrap();
 
 			let dest = Location::new(1, [Parachain(2)]);
-			let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			precompiles()
 				.prepare_test(

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -32,6 +32,10 @@ use sp_runtime::{
 };
 use sp_std::marker::PhantomData;
 
+/// System account size in bytes = Pallet_Name_Hash (16) + Storage_name_hash (16) +
+/// Blake2_128Concat (16) + AccountId (20) + AccountInfo (4 + 12 + AccountData (4* 16)) = 148
+pub const SYSTEM_ACCOUNT_SIZE: u64 = 148;
+
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
@@ -425,6 +429,7 @@ where
 						balance
 					},
 				},
+				SYSTEM_ACCOUNT_SIZE,
 			)?;
 
 			Some(Transfer {

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -30,7 +30,7 @@ use precompile_utils::{
 	testing::MockAccount,
 };
 use scale_info::TypeInfo;
-use sp_core::{ConstU32, H160, H256, U256};
+use sp_core::{H160, H256, U256};
 use sp_io;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_runtime::{
@@ -58,6 +58,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
@@ -105,6 +106,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -176,7 +178,7 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
 }

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -578,7 +578,7 @@ fn fails_if_called_by_smart_contract() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice address as it if was a smart contract.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
 
 			PrecompilesValue::get()
 				.prepare_test(
@@ -776,8 +776,8 @@ fn proxy_proxy_should_fail_if_called_by_smart_contract_for_a_non_eoa_account() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice & Bob addresses as if they are smart contracts.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Bob), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Bob), vec![10u8]);
 
 			// Bob allows Alice to make calls on his behalf
 			assert_ok!(RuntimeCall::Proxy(ProxyCall::add_proxy {

--- a/precompiles/xcm-utils/src/tests.rs
+++ b/precompiles/xcm-utils/src/tests.rs
@@ -86,7 +86,7 @@ fn test_get_account_sibling() {
 #[test]
 fn test_weight_message() {
 	ExtBuilder::default().build().execute_with(|| {
-		let message: Vec<u8> = xcm::VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let message: Vec<u8> = xcm::VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::weight_message {
 			message: message.into(),
@@ -118,7 +118,7 @@ fn test_get_units_per_second() {
 #[test]
 fn test_executor_clear_origin() {
 	ExtBuilder::default().build().execute_with(|| {
-		let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::xcm_execute {
 			message: xcm_to_execute.into(),
@@ -137,7 +137,7 @@ fn test_executor_clear_origin() {
 fn test_executor_send() {
 	ExtBuilder::default().build().execute_with(|| {
 		let withdrawn_asset: Asset = (Location::parent(), 1u128).into();
-		let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![
+		let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![
 			WithdrawAsset(vec![withdrawn_asset].into()),
 			InitiateReserveWithdraw {
 				assets: AssetFilter::Wild(All),
@@ -184,9 +184,9 @@ fn test_executor_transact() {
 			}
 			.encode();
 			encoded.append(&mut call_bytes);
-			let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![Transact {
+			let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![Transact {
 				origin_kind: OriginKind::SovereignAccount,
-				require_weight_at_most: Weight::from_parts(1_000_000_000u64, 5206u64),
+				fallback_max_weight: Some(Weight::from_parts(1_000_000_000u64, 5206u64)),
 				call: encoded.into(),
 			}]))
 			.encode();
@@ -198,7 +198,7 @@ fn test_executor_transact() {
 
 			precompiles()
 				.prepare_test(CryptoAlith, Precompile1, input)
-				.expect_cost(1100001001)
+				.expect_cost(276106001)
 				.expect_no_logs()
 				.execute_returns(());
 
@@ -211,7 +211,7 @@ fn test_executor_transact() {
 #[test]
 fn test_send_clear_origin() {
 	ExtBuilder::default().build().execute_with(|| {
-		let xcm_to_send = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+		let xcm_to_send = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 		let input = PCall::xcm_send {
 			dest: Location::parent(),
@@ -242,9 +242,9 @@ fn execute_fails_if_called_by_smart_contract() {
 		.build()
 		.execute_with(|| {
 			// Set code to Alice address as it if was a smart contract.
-			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			pallet_evm::Pallet::<Runtime>::create_account(H160::from(Alice), vec![10u8]);
 
-			let xcm_to_execute = VersionedXcm::<()>::V4(Xcm(vec![ClearOrigin])).encode();
+			let xcm_to_execute = VersionedXcm::<()>::from(Xcm(vec![ClearOrigin])).encode();
 
 			let input = PCall::xcm_execute {
 				message: xcm_to_execute.into(),

--- a/primitives/session-keys/src/inherent.rs
+++ b/primitives/session-keys/src/inherent.rs
@@ -13,14 +13,16 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonkit.  If not, see <http://www.gnu.org/licenses/>.
+extern crate alloc;
+
+use alloc::string::String;
 use parity_scale_codec::{Decode, Encode};
 use sp_inherents::{Error, InherentData, InherentIdentifier, IsFatalError};
-use sp_runtime::RuntimeString;
 
 #[derive(Encode)]
 #[cfg_attr(feature = "std", derive(Debug, Decode))]
 pub enum InherentError {
-	Other(RuntimeString),
+	Other(String),
 }
 
 impl IsFatalError for InherentError {

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -190,9 +190,8 @@ async fn build_relay_chain_interface(
 	if let cumulus_client_cli::RelayChainMode::ExternalRpc(rpc_target_urls) =
 		collator_options.relay_chain_mode
 	{
-		build_minimal_relay_chain_node_with_rpc(polkadot_config, task_manager, rpc_target_urls,
-		)
-		.await
+		build_minimal_relay_chain_node_with_rpc(polkadot_config, task_manager, rpc_target_urls)
+			.await
 	} else {
 		build_inprocess_relay_chain(
 			polkadot_config,

--- a/template/node/src/service.rs
+++ b/template/node/src/service.rs
@@ -22,11 +22,13 @@ use cumulus_client_parachain_inherent::{MockValidationDataInherentDataProvider, 
 use cumulus_client_service::{
 	prepare_node_config, start_relay_chain_tasks, DARecoveryProfile, StartRelayChainTasksParams,
 };
+use cumulus_primitives_core::CollectCollationInfo;
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node_with_rpc;
 
+use polkadot_primitives::UpgradeGoAhead;
 use polkadot_service::CollatorPair;
 
 // Substrate Imports
@@ -188,8 +190,9 @@ async fn build_relay_chain_interface(
 	if let cumulus_client_cli::RelayChainMode::ExternalRpc(rpc_target_urls) =
 		collator_options.relay_chain_mode
 	{
-		build_minimal_relay_chain_node_with_rpc(polkadot_config, task_manager, rpc_target_urls)
-			.await
+		build_minimal_relay_chain_node_with_rpc(polkadot_config, task_manager, rpc_target_urls,
+		)
+		.await
 	} else {
 		build_inprocess_relay_chain(
 			polkadot_config,

--- a/template/pallets/template/src/mock.rs
+++ b/template/pallets/template/src/mock.rs
@@ -24,6 +24,7 @@ parameter_types! {
 }
 
 impl system::Config for Test {
+	type ExtensionsWeightInfo = ();
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -347,7 +347,7 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
-    type ExtensionsWeightInfo = ();
+	type ExtensionsWeightInfo = ();
 }
 
 parameter_types! {

--- a/template/runtime/src/lib.rs
+++ b/template/runtime/src/lib.rs
@@ -13,7 +13,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+	ApplyExtrinsicResult, Cow, MultiSignature,
 };
 
 pub use nimbus_primitives::NimbusId;
@@ -347,6 +347,7 @@ impl frame_system::Config for Runtime {
 	type PreInherents = ();
 	type PostInherents = ();
 	type PostTransactions = ();
+    type ExtensionsWeightInfo = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
Cherry pick from [upstream](https://github.com/Moonsong-Labs/moonkit/pull/59/commits/3f61599b0716dd77a78cd761589f098f023c9d9d)

* feat: :arrow_up: upgrade to polkadot-sdk 2412

* fix: :bug: fix compilation errors

* chore: :arrow_up: upgrade frontier in lock file

* test: :white_check_mark: update expected_cost

* test: :white_check_mark: update more expected_costs

* test: :white_check_mark: fix more expected costs

* refactor: :coffin: remove dead code

* use storage growth in precompiles (mbip-5)

* refactor: :rotating_light: lint/fmt

* fix: tests to also create account metadata

* improve async backing logs